### PR TITLE
Fix MkDocs docs_dir path to root

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: AoH Guild House
 repo_url: https://github.com/<your-username>/aoh-guild-house
+docs_dir: .
 theme:
   name: material
   features:


### PR DESCRIPTION
## Summary
- configure MkDocs to look in repo root for documentation

## Testing
- `mkdocs build --strict` *(fails: command not found; mkdocs installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c09cf14c64832f925f014f5dac2964