### PR TITLE
docs: add qpp project to navigation

### DIFF
--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -2,5 +2,10 @@
 
 Open-source tools and products by the guild.
 
+- [Q++ GCC](qpp/README.md) – experimental GCC fork for quantum programming.
+- [EtherOS](etheros/README.md)
+- [Ethos](ethos/README.md)
+- [SymbolCast](symbolcast/README.md)
+
 License: Apache-2.0 (see repository [`LICENSE`](../LICENSE)).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,12 @@ nav:
   - Quest Board: QUEST_BOARD.md
   - Cycles: CYCLES.md
   - Main Quests:
-      - Tech: projects/README.md
+      - Tech:
+          - Overview: projects/README.md
+          - Q++ GCC: projects/qpp/README.md
+          - Ethos: projects/ethos/README.md
+          - EtherOS: projects/etheros/README.md
+          - SymbolCast: projects/symbolcast/README.md
       - Research: research/README.md
       - Art & Media: media/README.md
   - Support Quests:


### PR DESCRIPTION
## Summary
- Expose Tech subprojects in documentation navigation
- Include Q++ GCC alongside other Tech projects

## Testing
- `mkdocs build` *(fails: command not found; pip install mkdocs failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6256de41c832fae44626b63e99286